### PR TITLE
マップの再描画処理を修正

### DIFF
--- a/server/app/assets/javascript/map_image.coffee
+++ b/server/app/assets/javascript/map_image.coffee
@@ -201,6 +201,7 @@ class MapImage
     arrow(@ctx, x1, y1, x2, y2, 20, 40, 30, 7)
 
   clear: () ->
+    @ctx.clearRect(0, 0, @tag[0].width, @tag[0].height)
     @setImage()
     @setLayers()
 


### PR DESCRIPTION
二期になって透過PNGを使うようになり、マップ上にポインタなどをなんども表示させることで、半透明の部分が重なって濃く表示されるようになっていたのを修正しました

すでに描画した上から再描画する形になっていたのでその前に一旦全て消す処理を加えました