### PR TITLE
JDBCドライバをMariaDB Connector/Jに置き換える

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ CMD \
   ~/bin/sbt -v server/stage && \
   rm -f server/target/universal/stage/RUNNING_PID && \
   server/target/universal/stage/bin/myfleetgirlsserver \
-    -Ddb.default.url="jdbc:mysql://${DB_HOST}:${DB_PORT}/myfleet" \
+    -Ddb.default.url="jdbc:mariadb://${DB_HOST}:${DB_PORT}/myfleet" \
     -Ddb.default.user="root" \
     -Ddb.default.password=""

--- a/profiler/src/main/resources/application.conf.sample
+++ b/profiler/src/main/resources/application.conf.sample
@@ -1,4 +1,4 @@
-db.default.driver="com.mysql.jdbc.Driver"
-db.default.url="jdbc:mysql://localhost:3306/myfleet"
+db.default.driver="org.mariadb.jdbc.Driver"
+db.default.url="jdbc:mariadb://localhost:3306/myfleet"
 db.default.user=
 db.default.password=

--- a/profiler/src/main/scala/UserShipDB.scala
+++ b/profiler/src/main/scala/UserShipDB.scala
@@ -12,8 +12,8 @@ import scalikejdbc._
  */
 object UserShipDB {
   def main(args: Array[String]): Unit = {
-    Class.forName("com.mysql.jdbc.Driver")
-    ConnectionPool.singleton("jdbc:mysql://localhost:3306/myfleet", "myfleet", "myfleet")
+    Class.forName("org.mariadb.jdbc.Driver")
+    ConnectionPool.singleton("jdbc:mariadb://localhost:3306/myfleet", "myfleet", "myfleet")
 
     val count = Try { args(0).toInt }.getOrElse(20)
     val users = new UserIterator(0)

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
-libraryDependencies += "mysql" % "mysql-connector-java" % "5.1.39"
+libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "2.3.0"
 addSbtPlugin("org.scalikejdbc" %% "scalikejdbc-mapper-generator" % "3.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")
 addSbtPlugin("com.scalapenos" % "sbt-prompt" % "1.0.2")

--- a/project/scalikejdbc.properties.sample
+++ b/project/scalikejdbc.properties.sample
@@ -4,8 +4,8 @@
 # You can declare as many datasources as you want.
 # By convention, the default datasource is named `default`
 #
-jdbc.driver=com.mysql.jdbc.Driver
-jdbc.url=jdbc:mysql://localhost:3306/myfleet
+jdbc.driver=org.mariadb.jdbc.Driver
+jdbc.url=jdbc:mariadb://localhost:3306/myfleet
 jdbc.username=
 jdbc.password=
 

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc-play-initializer" % "2.6.0-scalikejdbc-3.3",
   "org.scalikejdbc" %% "scalikejdbc-syntax-support-macro" % scalikeJdbcVer,
   "com.github.nscala-time" %% "nscala-time" % "2.20.0",
-  "mysql" % "mysql-connector-java" % "5.1.47",
+  "org.mariadb.jdbc" % "mariadb-java-client" % "2.3.0",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "org.apache.abdera" % "abdera-parser" % "1.1.3",
   "net.sf.ehcache" % "ehcache" % "2.10.5",

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -27,8 +27,8 @@ play.i18n.langs = ["en"]
 # You can declare as many datasources as you want.
 # By convention, the default datasource is named `default`
 #
-db.default.driver="com.mysql.jdbc.Driver"
-db.default.url="jdbc:mysql://localhost:3306/myfleet"
+db.default.driver="org.mariadb.jdbc.Driver"
+db.default.url="jdbc:mariadb://localhost:3306/myfleet"
 db.default.migration.table=schema_version
 db.default.migration.auto=true
 


### PR DESCRIPTION
MySQL Connector/J から MariaDB Connector/J に変更します

MariaDBを利用する時のパフォーマンス向上が見込めます
参考: https://mariadb.com/resources/blog/mariadb-java-connector-driver-performance