### PR TITLE
戦果推計値の引継ぎ戦果に、前月の任務分が入っていなかったのを修正

### DIFF
--- a/server/app/tool/BattleScore.scala
+++ b/server/app/tool/BattleScore.scala
@@ -33,8 +33,9 @@ object BattleScore {
     val now = DateTime.now(Tokyo)
     val mHead = monthHead(now)
     val nowMonth = new Interval(mHead, now)
+    val lastMonth = new Interval(monthHead(now - 1.month), mHead)
     val eo = calcNowEo(memberId, nowMonth)
-    val lastEo = if(now.getMonthOfYear == 1) 0 else calcEo(memberId, new Interval(monthHead(now - 1.month), mHead)) / 35
+    val lastEo = if(now.getMonthOfYear == 1) 0 else (calcEo(memberId, lastMonth) + calcQuest(memberId, lastMonth)) / 35
     val quest = calcQuest(memberId, nowMonth)
     BattleScore(exp.monthly, exp.yearly, eo, lastEo, quest)
   }

--- a/server/app/views/user/user.scala.html
+++ b/server/app/views/user/user.scala.html
@@ -145,7 +145,7 @@
             <th>経験値</th>
             <th>引継戦果(経験値)</th>
             <th>EO</th>
-            <th>引継戦果(EO)</th>
+            <th>引継戦果(EO+任務)</th>
             <th>任務</th>
           </tr>
         </thead>


### PR DESCRIPTION
先月EO分に任務分も加える事によって対処。

EO分と任務分を分ける事も考えたけれど、Wikiの情報では合計を35で割っているので端数が出ないように一つにまとめて計算するようにした。